### PR TITLE
Dashboard css grid

### DIFF
--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -1,4 +1,5 @@
-// GENERAL WHITE CARDS
+// GENERAL WHITE BOXES
+// 1. Phone Design
 .dashboard-layout {
   p, h2 {
     margin: 0;
@@ -16,6 +17,7 @@
 .user, .skills, .card {
   width: 98%;
   height: auto;
+  // margin left/right auto centers the element
   margin-left: auto;
   margin-right: auto;
   margin-top: 15px;
@@ -24,6 +26,44 @@
   background-color: $white;
   border-radius: 3px;
   box-shadow: 1px 1px 2px rgba(0,0,0,0.2);
+}
+
+// 2. Landscape / Desktop design
+@media only screen and (min-width: 1024px) {
+  .dashboard-layout {
+    display: grid;
+    grid-template-columns: 400px 1fr;
+    grid-template-rows: 45% 45%;
+  }
+
+  .user {
+    grid-row: 1 / span 1;
+    grid-column: 1 span 1;
+  }
+
+  .skills {
+    grid-row: 2 / span 1;
+    grid-column: 1 / span 1;
+  }
+
+  .bookings {
+    grid-row: 1 / span 1;
+    grid-column: 2 / span 1;
+  }
+
+  .user, .skills {
+    width: 90%;
+  }
+
+  .skills, .bookings {
+    margin-bottom: 15px;
+  }
+
+  .bookings {
+    width: 95%;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 // USER
@@ -63,6 +103,7 @@
   border-radius: 3px;
 }
 // MANAGE BOOKINGS
+// 1. Phone design
 .bookings h1 {
   text-align: center;
 }
@@ -77,4 +118,29 @@
 }
 .card-left h2 {
   margin-top: 5px;
+}
+
+// 2. Landscape / Desktop design
+@media only screen and (min-width: 1024px) {
+  .card {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .card-left, .card-middle {
+    margin-right: 15px;
+  }
+
+  .card-left {
+    min-width: 15%;
+  }
+
+  .card-middle {
+    padding: 10px 0;
+  }
+
+  .card-right a {
+    margin: 5px;
+  }
 }

--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -17,7 +17,7 @@
 .user, .skills, .card {
   width: 98%;
   height: auto;
-  // margin left/right auto centers the element
+  // margin left/right: auto; centers the element
   margin-left: auto;
   margin-right: auto;
   margin-top: 15px;
@@ -30,12 +30,13 @@
 
 // 2. Landscape / Desktop design
 @media only screen and (min-width: 1024px) {
+  // Defining the grid
   .dashboard-layout {
     display: grid;
     grid-template-columns: 400px 1fr;
     grid-template-rows: 45% 45%;
   }
-
+  // Defining each element on the grid
   .user {
     grid-row: 1 / span 1;
     grid-column: 1 span 1;
@@ -50,7 +51,7 @@
     grid-row: 1 / span 1;
     grid-column: 2 / span 1;
   }
-
+  // Minor adjustments
   .user, .skills {
     width: 90%;
   }
@@ -63,6 +64,17 @@
     width: 95%;
     margin-left: auto;
     margin-right: auto;
+  }
+}
+
+// 3. Tablet Portrait design
+@media only screen and (min-width: 768px) and (max-width: 1024px) {
+  .user {
+    width: 50%;
+  }
+
+  .skills, .card {
+    width: 90%;
   }
 }
 


### PR DESCRIPTION
Added a CSS grid for tablet (landscape) and desktop.
Tablet (landscape) and Desktop
![dashboard-grid-landscape-desktop](https://user-images.githubusercontent.com/29100240/31863811-fc1393ee-b74a-11e7-9da1-8304c5f539bb.png)
Tablet (portrait) - User info box is only width: 50%;
![dashboard-grid-tablet-portrait](https://user-images.githubusercontent.com/29100240/31863812-fc2a66be-b74a-11e7-9ca3-b963200e3bb4.png)
Phone
![dashboard-grid-phone](https://user-images.githubusercontent.com/29100240/31863813-fc478550-b74a-11e7-8392-b28bc6806400.png)
